### PR TITLE
[T02] backend.spec 신규 작성 + pytest TDD 환경 구축

### DIFF
--- a/IMPLEMENTATION_TICKETS.md
+++ b/IMPLEMENTATION_TICKETS.md
@@ -143,3 +143,4 @@ Electron main process → `backend.exe --port {N}` spawn → health poll → `Br
 3. **빌드 검증** — 코드 수정 후 `npm run build` (프론트) 또는 `scripts/build.bat` (전체) 확인 필수
 4. **타임스탬프** — `playerMessageTime` 기준 유지. `messageTime` 벽시계 기준 로직 추가 금지
 5. **한국어 파일 쓰기** — PowerShell `Set-Content` 인코딩 이슈 → `python Path.write_text(encoding='utf-8')` 사용
+6. **TDD 기반 개발** — 구현 전 테스트 먼저 작성 (pytest). Red → Green 사이클을 통과한 뒤 PR 오픈. 테스트 위치: `tests/` (백엔드), `electron/tests/` (Electron)

--- a/backend.spec
+++ b/backend.spec
@@ -23,8 +23,6 @@
 
 from pathlib import Path
 
-block_cipher = None
-
 # ---------------------------------------------------------------------------
 # 리소스 경로 정의
 # ---------------------------------------------------------------------------
@@ -99,13 +97,10 @@ a = Analysis(
         "webview", "clr", "clr_loader",
         "tkinter", "tkinter.font", "tkinter.ttk",
     ],
-    win_no_prefer_redirects=False,
-    win_private_assemblies=False,
-    cipher=block_cipher,
     noarchive=False,
 )
 
-pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+pyz = PYZ(a.pure, a.zipped_data)
 
 exe = EXE(
     pyz,

--- a/backend.spec
+++ b/backend.spec
@@ -1,0 +1,133 @@
+# -*- mode: python ; coding: utf-8 -*-
+#
+# backend.spec
+# PyInstaller 빌드 명세 — headless FastAPI 서버 전용
+#
+# 빌드 방법:
+#   pip install pyinstaller
+#   pyinstaller backend.spec --clean --noconfirm
+#
+# 출력: dist/backend/ 폴더 → backend.exe 포함
+#
+# 전제 조건:
+#   - 프론트엔드를 먼저 빌드해 frontend/dist/ 를 생성해야 합니다.
+#     (cd frontend && npm run build)
+#   - 기존 ShortsGak.spec(pywebview 포함)과는 다른 파일입니다.
+#     Electron이 backend.exe 를 자식 프로세스로 실행합니다.
+#
+# 주요 차이점 (vs ShortsGak.spec):
+#   - entry point : backend/backend_server.py  (desktop_launcher/run_desktop.py 아님)
+#   - console=True : GUI 없음, Electron 이 창을 담당
+#   - pywebview / clr / clr_loader / tkinter 완전 제거 → 시스템 의존성 없음
+#   - 출력 이름 : backend  (→ dist/backend/backend.exe)
+
+from pathlib import Path
+
+block_cipher = None
+
+# ---------------------------------------------------------------------------
+# 리소스 경로 정의
+# ---------------------------------------------------------------------------
+ROOT = Path(SPECPATH)  # backend.spec 이 위치한 프로젝트 루트
+
+added_datas = [
+    # 프론트엔드 정적 파일: FastAPI 가 직접 서빙
+    (str(ROOT / "frontend" / "dist"), "frontend/dist"),
+    # 백엔드 패키지: _MEIPASS/backend/app/ 에 배치
+    # backend_server.py 가 _MEIPASS/backend 를 sys.path 에 추가하므로
+    # `import app.main` 이 동작합니다
+    (str(ROOT / "backend" / "app"), "backend/app"),
+]
+
+# ---------------------------------------------------------------------------
+# Hidden imports
+# uvicorn / fastapi 의 동적 로더는 PyInstaller 가 자동 탐지하지 못하는 경우가 있음
+# pywebview · clr · tkinter 는 Electron 전환으로 완전 제거
+# ---------------------------------------------------------------------------
+hidden_imports = [
+    # uvicorn internals
+    "uvicorn.logging",
+    "uvicorn.loops",
+    "uvicorn.loops.auto",
+    "uvicorn.loops.asyncio",
+    "uvicorn.loops.uvloop",
+    "uvicorn.protocols",
+    "uvicorn.protocols.http",
+    "uvicorn.protocols.http.auto",
+    "uvicorn.protocols.http.h11_impl",
+    "uvicorn.protocols.http.httptools_impl",
+    "uvicorn.protocols.websockets",
+    "uvicorn.protocols.websockets.auto",
+    "uvicorn.protocols.websockets.wsproto_impl",
+    "uvicorn.protocols.websockets.websockets_impl",
+    "uvicorn.lifespan",
+    "uvicorn.lifespan.off",
+    "uvicorn.lifespan.on",
+    # fastapi / starlette
+    "fastapi",
+    "fastapi.middleware.cors",
+    "starlette.staticfiles",
+    "starlette.responses",
+    # app 패키지 (backend/app/)
+    "app.main",
+    "app.schemas",
+    "app.parser",
+    "app.analyzer",
+    "app.logging_config",
+    "app.chatlog_cache",
+    "app.chatlog_fetcher",
+]
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+a = Analysis(
+    [str(ROOT / "backend" / "backend_server.py")],
+    pathex=[
+        str(ROOT),
+        str(ROOT / "backend"),  # PyInstaller 빌드 시 `app` 패키지 탐색 경로
+    ],
+    binaries=[],
+    datas=added_datas,
+    hiddenimports=hidden_imports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        "matplotlib", "numpy", "scipy",
+        # GUI / WebView 관련 — Electron 전환으로 불필요
+        "webview", "clr", "clr_loader",
+        "tkinter", "tkinter.font", "tkinter.ttk",
+    ],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="backend",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,   # headless 서버 — 터미널 출력 필요 (LISTENING_PORT= 등)
+    icon=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="backend",  # 출력: dist/backend/
+)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+asyncio_mode = auto

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""conftest.py
+
+pytest 전역 설정. backend/ 를 sys.path 에 추가해
+tests 에서 `import backend_server`, `import app.*` 가 가능하도록 한다.
+"""
+import sys
+from pathlib import Path
+
+# 프로젝트 루트 (tests/ 의 상위)
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND_DIR = ROOT / "backend"
+
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))

--- a/tests/test_backend_server.py
+++ b/tests/test_backend_server.py
@@ -1,0 +1,161 @@
+"""tests/test_backend_server.py
+
+backend_server.py 의 동작을 검증하는 테스트.
+T02 (backend.spec) 에서 번들할 진입점이 올바르게 동작함을 보장한다.
+
+TDD 절차:
+1. [Red]   이 파일 작성 → 구현 없을 때 실패 확인
+2. [Green] backend_server.py / backend.spec 구현 → 전체 통과 확인
+3. [Refactor] 필요 시 정리
+"""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND_SERVER = ROOT / "backend" / "backend_server.py"
+PYTHON = sys.executable
+
+# ---------------------------------------------------------------------------
+# 헬퍼
+# ---------------------------------------------------------------------------
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _wait_http(url: str, timeout: float = 10.0, interval: float = 0.2) -> bool:
+    """url 이 200 을 반환할 때까지 폴링, 타임아웃이면 False."""
+    import urllib.error
+    import urllib.request
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=1) as r:
+                if r.status == 200:
+                    return True
+        except (urllib.error.URLError, OSError):
+            pass
+        time.sleep(interval)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _find_free_port, _parse_args
+# ---------------------------------------------------------------------------
+
+class TestFindFreePort:
+    def test_returns_integer(self):
+        import backend_server
+        port = backend_server._find_free_port()
+        assert isinstance(port, int)
+
+    def test_port_in_valid_range(self):
+        import backend_server
+        port = backend_server._find_free_port()
+        assert 1024 <= port <= 65535
+
+    def test_port_is_free(self):
+        """반환된 포트에 즉시 바인딩 가능해야 한다."""
+        import backend_server
+        port = backend_server._find_free_port()
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", port))  # OSError 없으면 성공
+
+
+class TestParseArgs:
+    def test_port_flag(self, monkeypatch):
+        import backend_server
+        monkeypatch.setattr(sys, "argv", ["backend_server.py", "--port", "12345"])
+        args = backend_server._parse_args()
+        assert args.port == 12345
+
+    def test_port_default_is_none(self, monkeypatch):
+        import backend_server
+        monkeypatch.setattr(sys, "argv", ["backend_server.py"])
+        args = backend_server._parse_args()
+        assert args.port is None
+
+    def test_no_host_arg(self, monkeypatch):
+        """--host 플래그는 존재하지 않아야 한다 (보안 원칙)."""
+        import backend_server
+        monkeypatch.setattr(sys, "argv", ["backend_server.py", "--host", "0.0.0.0"])
+        with pytest.raises(SystemExit):
+            backend_server._parse_args()
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — 실제 서버 subprocess
+# ---------------------------------------------------------------------------
+
+class TestBackendServerProcess:
+    """backend_server.py 를 subprocess 로 실행해 동작을 검증한다."""
+
+    @pytest.fixture()
+    def server(self):
+        """지정 포트로 서버를 시작하고, 테스트 종료 시 종료한다."""
+        port = _free_port()
+        proc = subprocess.Popen(
+            [PYTHON, str(BACKEND_SERVER), "--port", str(port)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=str(ROOT),
+        )
+        yield proc, port
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    def test_emits_listening_port_to_stdout(self, server):
+        """서버 시작 시 stdout 첫 줄에 LISTENING_PORT=<N> 이 출력된다."""
+        proc, port = server
+        # 최대 5초 대기
+        proc.stdout._sock.settimeout(5) if hasattr(proc.stdout, '_sock') else None
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            line = proc.stdout.readline()
+            if line.startswith("LISTENING_PORT="):
+                emitted_port = int(line.strip().split("=")[1])
+                assert emitted_port == port
+                return
+        pytest.fail("LISTENING_PORT= 가 5초 내에 stdout에 출력되지 않았습니다.")
+
+    def test_health_endpoint_returns_200(self, server):
+        """서버 시작 후 /health 가 200 을 반환해야 한다."""
+        proc, port = server
+        url = f"http://127.0.0.1:{port}/health"
+        assert _wait_http(url, timeout=15), f"{url} 이 15초 내에 응답하지 않았습니다."
+
+    def test_port_conflict_exits_with_code_1(self):
+        """이미 사용 중인 포트로 서버를 실행하면 exit code 1 로 종료된다."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as blocker:
+            blocker.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            blocker.bind(("127.0.0.1", 0))
+            blocker.listen(1)
+            used_port = blocker.getsockname()[1]
+
+            proc = subprocess.run(
+                [PYTHON, str(BACKEND_SERVER), "--port", str(used_port)],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=str(ROOT),
+            )
+            assert proc.returncode == 1, (
+                f"반환 코드가 1이어야 하는데 {proc.returncode}입니다.\n"
+                f"stderr: {proc.stderr}"
+            )
+            assert "ERROR" in proc.stderr, "stderr에 ERROR 메시지가 없습니다."


### PR DESCRIPTION
## 개요

EPIC-01-T02: `backend.spec` (PyInstaller headless 서버 번들) 신규 작성.
TDD 원칙에 따라 테스트를 먼저 작성하고 Green 확인 후 spec 파일을 작성했습니다.

## TDD 사이클

### Red → Green

| 단계 | 내용 |
|---|---|
| Red | `tests/test_backend_server.py` 작성 → 6개 단위 테스트 `ModuleNotFoundError` 실패 |
| 원인 파악 | `tests/conftest.py`의 `Path(__file__).resolve().parent`가 `tests/`를 가리켜 `tests/backend/`로 잘못 탐색 |
| Fix | `.parents[1]`로 프로젝트 루트 정확히 지정 |
| Green | 9/9 통과 |

```
9 passed in 2.19s
```

## 변경 파일

| 파일 | 변경 |
|---|---|
| `backend.spec` | 신규 — headless PyInstaller 번들 명세 |
| `pytest.ini` | 신규 — testpaths, asyncio_mode 설정 |
| `tests/__init__.py` | 신규 |
| `tests/conftest.py` | 신규 — sys.path 설정 |
| `tests/test_backend_server.py` | 신규 — 단위 9개 (TestFindFreePort, TestParseArgs, TestBackendServerProcess) |
| `IMPLEMENTATION_TICKETS.md` | 원칙 6번 TDD 기반 개발 추가 |

## backend.spec 핵심 변경 (vs 기존 ShortsGak.spec)

- **entry point**: `backend/backend_server.py` (desktop_launcher 제거)
- **console=True**: headless 서버, 터미널 출력 가능
- **제거**: `webview`, `clr`, `clr_loader`, `tkinter` 완전 삭제 → 시스템 의존성 없음
- **출력**: `dist/backend/backend.exe`

## 테스트 커버리지

- `_find_free_port()`: 반환값 타입, 범위, 즉시 바인딩 가능성
- `_parse_args()`: `--port` 파싱, 기본값, `--host` 플래그 부재(보안)
- subprocess 통합: `LISTENING_PORT=` stdout 출력, `/health` 200, 포트 충돌 exit(1)

## 연관 이슈

Closes #3
Part of #1
