### PR TITLE
[EPIC-01-T03] electron/ 디렉터리 및 Electron 앱 작성

### DIFF
--- a/electron/.gitignore
+++ b/electron/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -1,0 +1,25 @@
+appId: com.mandarincrow.shortsgak
+productName: ShortsGak
+
+directories:
+  output: dist/electron
+
+files:
+  - main.js
+  - utils.js
+  - package.json
+
+extraResources:
+  - from: ../dist/backend
+    to: backend
+    filter:
+      - "**/*"
+
+win:
+  target:
+    - target: dir
+      arch:
+        - x64
+
+# 'dir' target produces dist/electron/win-unpacked/ — scripts/package_release.bat
+# zips this folder as ShortsGak-win64-<DATE>.zip (zip 배포 방식 유지).

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,0 +1,177 @@
+'use strict'
+/**
+ * electron/main.js
+ * Electron main process — manages backend.exe lifecycle and BrowserWindow.
+ */
+
+const { app, BrowserWindow, dialog } = require('electron')
+const { spawn } = require('child_process')
+const path = require('path')
+const readline = require('readline')
+const { findFreePort, parseListeningPort } = require('./utils')
+
+// ─────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────
+const HEALTH_POLL_INTERVAL_MS = 250
+const HEALTH_POLL_TIMEOUT_MS = 30_000
+const WINDOW_WIDTH = 1100
+const WINDOW_HEIGHT = 760
+
+// ─────────────────────────────────────────────────────────────────
+// Backend executable path
+//   frozen (packaged): resources/backend/backend.exe  (electron-builder extraResources)
+//   dev:               dist/backend/backend.exe        (PyInstaller output)
+// ─────────────────────────────────────────────────────────────────
+function getBackendExePath() {
+  if (app.isPackaged) {
+    return path.join(process.resourcesPath, 'backend', 'backend.exe')
+  }
+  return path.join(__dirname, '..', 'dist', 'backend', 'backend.exe')
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Health polling
+// ─────────────────────────────────────────────────────────────────
+function pollUntilHealthy(port) {
+  return new Promise((resolve, reject) => {
+    const url = `http://127.0.0.1:${port}/health`
+    const deadline = Date.now() + HEALTH_POLL_TIMEOUT_MS
+
+    function attempt() {
+      if (Date.now() >= deadline) {
+        reject(new Error(`Health check timed out after ${HEALTH_POLL_TIMEOUT_MS / 1000}s`))
+        return
+      }
+      fetch(url)
+        .then((res) => {
+          if (res.ok) resolve()
+          else setTimeout(attempt, HEALTH_POLL_INTERVAL_MS)
+        })
+        .catch(() => setTimeout(attempt, HEALTH_POLL_INTERVAL_MS))
+    }
+
+    attempt()
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────
+let mainWindow = null
+let backendProc = null
+
+function killBackend() {
+  if (backendProc) {
+    try {
+      backendProc.kill()
+    } catch (_) {
+      // process may already be gone
+    }
+    backendProc = null
+  }
+}
+
+async function launchApp() {
+  let port
+  try {
+    port = await findFreePort()
+  } catch (err) {
+    dialog.showErrorBox('ShortsGak', `포트 탐색 실패:\n${err.message}`)
+    app.quit()
+    return
+  }
+
+  const exePath = getBackendExePath()
+  backendProc = spawn(exePath, ['--port', String(port)], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  backendProc.on('error', (err) => {
+    dialog.showErrorBox(
+      'ShortsGak',
+      `서버 시작 실패:\n${err.message}\n\n경로: ${exePath}`
+    )
+    app.quit()
+  })
+
+  backendProc.stderr.on('data', (data) => {
+    const text = data.toString()
+    if (text.startsWith('ERROR:')) {
+      console.error('[backend stderr]', text.trim())
+    }
+  })
+
+  // Wait for LISTENING_PORT=N on stdout, then poll /health
+  const rl = readline.createInterface({ input: backendProc.stdout })
+  let portConfirmed = false
+
+  const portPromise = new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Timed out waiting for LISTENING_PORT signal'))
+    }, HEALTH_POLL_TIMEOUT_MS)
+
+    rl.on('line', (line) => {
+      if (portConfirmed) return
+      const parsed = parseListeningPort(line)
+      if (parsed !== null) {
+        portConfirmed = true
+        clearTimeout(timeout)
+        resolve(parsed)
+      }
+    })
+
+    backendProc.on('exit', (code) => {
+      if (!portConfirmed) {
+        clearTimeout(timeout)
+        reject(new Error(`backend.exe 종료 (code ${code}) before LISTENING_PORT`))
+      }
+    })
+  })
+
+  let confirmedPort
+  try {
+    confirmedPort = await portPromise
+  } catch (err) {
+    dialog.showErrorBox('ShortsGak', `서버 시작 실패:\n${err.message}`)
+    killBackend()
+    app.quit()
+    return
+  }
+
+  try {
+    await pollUntilHealthy(confirmedPort)
+  } catch (err) {
+    dialog.showErrorBox('ShortsGak', `서버 응답 없음:\n${err.message}`)
+    killBackend()
+    app.quit()
+    return
+  }
+
+  // Server ready — open window
+  mainWindow = new BrowserWindow({
+    width: WINDOW_WIDTH,
+    height: WINDOW_HEIGHT,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+    },
+  })
+
+  mainWindow.loadURL(`http://127.0.0.1:${confirmedPort}`)
+
+  mainWindow.on('closed', () => {
+    mainWindow = null
+  })
+}
+
+app.whenReady().then(launchApp)
+
+app.on('window-all-closed', () => {
+  killBackend()
+  app.quit()
+})
+
+app.on('before-quit', () => {
+  killBackend()
+})

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "shortsgak",
+  "version": "1.0.0",
+  "description": "ShortsGak - 치지직 VOD 채팅 하이라이트 분석기",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "test": "node tests/utils.test.js",
+    "dist": "electron-builder"
+  },
+  "devDependencies": {
+    "electron": "^35.0.0",
+    "electron-builder": "^25.0.0"
+  }
+}

--- a/electron/package.json
+++ b/electron/package.json
@@ -9,7 +9,7 @@
     "dist": "electron-builder"
   },
   "devDependencies": {
-    "electron": "^35.0.0",
-    "electron-builder": "^25.0.0"
+    "electron": "latest",
+    "electron-builder": "latest"
   }
 }

--- a/electron/tests/utils.test.js
+++ b/electron/tests/utils.test.js
@@ -1,0 +1,98 @@
+'use strict'
+/**
+ * electron/tests/utils.test.js
+ * Pure Node.js unit tests for electron/utils.js
+ * Run with: node electron/tests/utils.test.js
+ */
+
+const assert = require('assert')
+const { parseListeningPort, findFreePort } = require('../utils')
+
+let passed = 0
+let failed = 0
+
+function test(name, fn) {
+  try {
+    fn()
+    console.log(`  [OK] ${name}`)
+    passed++
+  } catch (err) {
+    console.error(`  [FAIL] ${name}`)
+    console.error(`         ${err.message}`)
+    failed++
+  }
+}
+
+async function asyncTest(name, fn) {
+  try {
+    await fn()
+    console.log(`  [OK] ${name}`)
+    passed++
+  } catch (err) {
+    console.error(`  [FAIL] ${name}`)
+    console.error(`         ${err.message}`)
+    failed++
+  }
+}
+
+// ─────────────────────────────────────────
+// parseListeningPort tests
+// ─────────────────────────────────────────
+console.log('\nparseListeningPort')
+test('returns port number for valid LISTENING_PORT line', () => {
+  assert.strictEqual(parseListeningPort('LISTENING_PORT=18765'), 18765)
+})
+
+test('returns port number when line has trailing whitespace/newline', () => {
+  assert.strictEqual(parseListeningPort('LISTENING_PORT=8080\r\n'), 8080)
+})
+
+test('returns null for unrelated line', () => {
+  assert.strictEqual(parseListeningPort('INFO: uvicorn started'), null)
+})
+
+test('returns null for empty string', () => {
+  assert.strictEqual(parseListeningPort(''), null)
+})
+
+test('returns null for partial match (no number)', () => {
+  assert.strictEqual(parseListeningPort('LISTENING_PORT='), null)
+})
+
+test('returns null for zero port', () => {
+  assert.strictEqual(parseListeningPort('LISTENING_PORT=0'), null)
+})
+
+test('handles LISTENING_PORT with extra prefix text', () => {
+  // Must be exact prefix — extra leading text should not match
+  assert.strictEqual(parseListeningPort('extra LISTENING_PORT=1234'), null)
+})
+
+// ─────────────────────────────────────────
+// findFreePort tests
+// ─────────────────────────────────────────
+console.log('\nfindFreePort')
+
+async function runAsyncTests() {
+  await asyncTest('returns a positive integer port number', async () => {
+    const port = await findFreePort()
+    assert.ok(typeof port === 'number', 'port should be a number')
+    assert.ok(port > 0 && port <= 65535, `port ${port} out of valid range`)
+  })
+
+  await asyncTest('returns different ports on consecutive calls', async () => {
+    const p1 = await findFreePort()
+    const p2 = await findFreePort()
+    // Ports should not collide (highly unlikely if OS properly marks them reserved briefly)
+    // We just check both are valid
+    assert.ok(p1 > 0 && p2 > 0)
+  })
+
+  // ── summary ──────────────────────────────
+  console.log(`\n${passed} passed, ${failed} failed`)
+  if (failed > 0) {
+    process.exitCode = 1
+  }
+}
+
+runAsyncTests()

--- a/electron/utils.js
+++ b/electron/utils.js
@@ -1,0 +1,40 @@
+'use strict'
+/**
+ * electron/utils.js
+ * Pure utility functions extracted for unit testability.
+ */
+
+const net = require('net')
+
+/**
+ * Find a free TCP port by asking the OS to assign one.
+ * @returns {Promise<number>} available port number
+ */
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port
+      server.close((err) => {
+        if (err) reject(err)
+        else resolve(port)
+      })
+    })
+    server.on('error', reject)
+  })
+}
+
+/**
+ * Parse a LISTENING_PORT=N signal line emitted by backend.exe to stdout.
+ * @param {string} line - single line of text (may include \r\n)
+ * @returns {number|null} port number, or null if not a valid signal line
+ */
+function parseListeningPort(line) {
+  const trimmed = line.trim()
+  const match = trimmed.match(/^LISTENING_PORT=(\d+)$/)
+  if (!match) return null
+  const port = parseInt(match[1], 10)
+  return port > 0 ? port : null
+}
+
+module.exports = { findFreePort, parseListeningPort }


### PR DESCRIPTION
## 개요

Issue #4 대응. pywebview를 대체하는 Electron main process 및 관련 파일 신규 작성.

## 변경 파일

| 파일 | 변경 |
|------|------|
| `electron/package.json` | 신규 — electron, electron-builder devDependencies |
| `electron/utils.js` | 신규 — `findFreePort()`, `parseListeningPort()` (단위테스트 분리) |
| `electron/main.js` | 신규 — Electron main process |
| `electron/electron-builder.yml` | 신규 — Windows dir 타겟, extraResources 설정 |
| `electron/tests/utils.test.js` | 신규 — 9개 순수 Node.js 단위 테스트 |

## 구현 요약

### electron/utils.js
- `findFreePort()`: `net.createServer` 활용, OS에 포트 할당 요청 후 즉시 해제 → 반환
- `parseListeningPort(line)`: `LISTENING_PORT=N` 패턴 정확히 파싱, 0이하/빈 값 거부

### electron/main.js 흐름
1. `findFreePort()` → 가용 포트(N) 확보
2. `backend.exe --port N` spawn (frozen: `resources/backend`, dev: `dist/backend`)
3. stdout readline 으로 `LISTENING_PORT=N` 수신 (30초 타임아웃)
4. `GET /health` 폴링 (250ms 간격, 30초 최대)
5. `BrowserWindow(1100×760)` 생성 → `loadURL(http://127.0.0.1:N)`
6. `window-all-closed` / `before-quit` 시 `backendProc.kill()`
7. 모든 실패 경로에서 `dialog.showErrorBox` 표시 후 `app.quit()`

### electron/electron-builder.yml
- target: `dir` → `dist/electron/win-unpacked/` (T04의 package_release.bat에서 zip)
- `extraResources`: `dist/backend/**` → `resources/backend` (backend.exe 번들)

## 셀프 리뷰 체크
- [x] `nodeIntegration: false`, `contextIsolation: true` — 보안 원칙 준수
- [x] 호스트 `127.0.0.1` 고정 — 외부 노출 없음
- [x] `findFreePort` / `parseListeningPort` 분리 → 단위 테스트 가능 구조
- [x] 테스트 9개 전부 통과 (`node electron/tests/utils.test.js`)
- [x] `app.isPackaged` 분기로 frozen/dev 경로 모두 처리
- [x] stderr `ERROR:` 로그 콘솔 출력

## 의존성
- Closes #4
- Depends on #2 (T01 `backend_server.py` — `LISTENING_PORT` 프로토콜 확정됨)
