### PR TITLE
[EPIC-01-T04] 빌드 스크립트 수정 (Electron 파이프라인)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,7 +15,7 @@ echo
 # ─────────────────────────────────────────────
 # 1. 프론트엔드 빌드
 # ─────────────────────────────────────────────
-echo "[1/4] 프론트엔드 빌드 중..."
+echo "[1/5] 프론트엔드 빌드 중..."
 if ! command -v npm &>/dev/null; then
     echo "[ERROR] npm 을 찾을 수 없습니다. Node.js 를 설치하세요."
     exit 1
@@ -31,7 +31,7 @@ echo
 # ─────────────────────────────────────────────
 # 2. Python 가상환경 준비
 # ─────────────────────────────────────────────
-echo "[2/4] Python 가상환경 준비 중..."
+echo "[2/5] Python 가상환경 준비 중..."
 
 if [ ! -d ".venv" ]; then
     python3 -m venv .venv
@@ -41,27 +41,42 @@ fi
 source .venv/bin/activate
 
 pip install -U pip --quiet
-pip install -r backend/requirements.txt -r desktop_launcher/requirements.txt --quiet
+pip install -r backend/requirements.txt --quiet
 echo "[OK] 가상환경 및 의존성 준비 완료"
 echo
 
 # ─────────────────────────────────────────────
-# 3. PyInstaller 설치 및 빌드
+# 3. PyInstaller 빌드
 # ─────────────────────────────────────────────
-echo "[3/4] PyInstaller 빌드 중..."
+echo "[3/5] PyInstaller 빌드 중..."
 pip install pyinstaller --quiet
-pyinstaller ShortsGak.spec --clean --noconfirm
-echo "[OK] 빌드 성공"
+pyinstaller backend.spec --clean --noconfirm
+echo "[OK] backend.exe 빌드 성공"
 echo
 
 # ─────────────────────────────────────────────
-# 4. 결과 요약
+# 4. Electron 빌드
 # ─────────────────────────────────────────────
-echo "[4/4] 빌드 결과"
+echo "[4/5] Electron 빌드 중..."
+if ! command -v npm &>/dev/null; then
+    echo "[ERROR] npm 을 찾을 수 없습니다. Node.js 를 설치하세요."
+    exit 1
+fi
+
+cd electron
+npm install
+npx electron-builder
+cd "$ROOT"
+echo "[OK] Electron 빌드 성공"
+echo
+
+# ─────────────────────────────────────────────
+# 5. 결과 요약
+# ─────────────────────────────────────────────
+echo "[5/5] 빌드 결과"
 echo "----------------------------------------"
-echo "  실행 파일: $ROOT/dist/ShortsGak/ShortsGak"
-echo "  배포 폴더: $ROOT/dist/ShortsGak/"
+echo "  backend.exe : $ROOT/dist/backend/backend.exe"
+echo "  Electron 앱 : $ROOT/electron/dist/win-unpacked/ (Windows 빌드 시)"
 echo "----------------------------------------"
-echo "  Linux/macOS에서 pywebview GUI 확인 시 GTK 또는 Qt 런타임이 필요합니다."
-echo "  Windows exe 배포는 Windows 환경에서 build.bat 을 사용하세요."
+echo "  NOTE: Windows exe 배포는 Windows 환경에서 build.bat 을 사용하세요."
 echo "============================================================"

--- a/scripts/package_release.bat
+++ b/scripts/package_release.bat
@@ -4,14 +4,14 @@ setlocal EnableExtensions EnableDelayedExpansion
 set "ROOT=%~dp0.."
 cd /d "%ROOT%"
 
-set "DIST_DIR=%ROOT%\dist\ShortsGak"
+set "DIST_DIR=%ROOT%\electron\dist\win-unpacked"
 set "RELEASE_DIR=%ROOT%\release"
 set "RELEASE_README=%RELEASE_DIR%\README.txt"
 set "VERSION=%~1"
 
 if not exist "%DIST_DIR%" (
     echo [ERROR] Dist directory not found: "%DIST_DIR%"
-    echo [HINT] Run scripts\build.bat first.
+    echo [HINT] Run scripts\build.bat first (Step 4: Electron build must complete).
     exit /b 1
 )
 
@@ -33,7 +33,6 @@ echo.
 echo [Recommended Environment]
 echo - Windows 10/11
 echo - Internet connection ^(required for auto chatlog fetch^)
-echo - WebView2 Runtime
 echo.
 echo [Troubleshooting]
 echo - If you see "Failed to fetch", close the app completely and run it again.


### PR DESCRIPTION
## 개요

Issue #5 대응. 기존 pywebview 기반 빌드 파이프라인을 Electron 파이프라인으로 교체.

## 변경 파일

| 파일 | 변경 |
|------|------|
| `scripts/build.bat` | 수정 |
| `scripts/build.sh` | 수정 |
| `scripts/package_release.bat` | 수정 |

## 변경 요약

### scripts/build.bat

| Step | 이전 | 이후 |
|------|------|------|
| Step 2 (Python 의존성) | `-r backend\requirements.txt -r desktop_launcher\requirements.txt` | `-r backend\requirements.txt` (desktop_launcher 제거) |
| Step 3 (PyInstaller) | `pyinstaller ShortsGak.spec` → `dist/ShortsGak/` | `pyinstaller backend.spec` → `dist/backend/` |
| Step 4 (신규) | - | `cd electron && npm install && npx electron-builder` → `electron/dist/win-unpacked/` |
| Step 5 (구 Step 4) | `package_release.bat` | 동일, 번호만 변경 |
| Summary exe 경로 | `dist\ShortsGak\ShortsGak.exe` | `electron\dist\win-unpacked\ShortsGak.exe` |
| Step 라벨 | `[N/4]` | `[N/5]` |

### scripts/build.sh

- Step 2: `desktop_launcher/requirements.txt` 제거
- Step 3: `pyinstaller backend.spec` (구 `ShortsGak.spec`)
- Step 4 (신규): Electron `npm install` + `electron-builder`
- Step 5: 결과 요약, 출력 경로 갱신
- 전체 step 카운트 `[N/4]` → `[N/5]`

### scripts/package_release.bat

- `DIST_DIR`: `dist\ShortsGak` → `electron\dist\win-unpacked`
- 릴리즈 README.txt: WebView2 Runtime 항목 제거
- 힌트 메시지: Electron 빌드 step 언급 추가

## 셀프 리뷰 체크
- [x] `cd electron` 후 에러 시 `cd "%ROOT%"` 복귀 처리
- [x] `npm install` 실패 시 즉시 exit /b 1
- [x] Linux/macOS build.sh도 동기화
- [x] package_release.bat zip 로직 자체는 변경 없음 (경로만 변경)

## 의존성
- Closes #5
- Depends on #3 (T02 `backend.spec`) and #4 (T03 `electron/`)
